### PR TITLE
Fixed issue w/ event listeners causing NPE

### DIFF
--- a/components/RecentProductionsList.vue
+++ b/components/RecentProductionsList.vue
@@ -69,7 +69,7 @@ export default {
   mounted () {
     this.$refs.pastProdList.SimpleBar.getScrollElement().addEventListener('scroll', this.handleScroll)
   },
-  destroyed () {
+  beforeDestroy () {
     this.$refs.pastProdList.SimpleBar.getScrollElement().removeEventListener('scroll', this.handleScroll)
   },
   methods: {


### PR DESCRIPTION
RecentProductionsList was attempting to remove an event listener in the destroyed() hook, and as such the element had already been removed.