### PR TITLE
Update Travis badge to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br>
 
 [![codecov](https://codecov.io/gh/rpitv/glimpse-ui/branch/master/graph/badge.svg)](https://codecov.io/gh/rpitv/glimpse-ui)
-[![Build Status](https://travis-ci.org/rpitv/glimpse-ui.svg?branch=master)](https://travis-ci.org/rpitv/glimpse-ui)
+[![Build Status](https://travis-ci.com/rpitv/glimpse-ui.svg?branch=master)](https://travis-ci.com/rpitv/glimpse-ui)
 [![License](https://img.shields.io/badge/license-GNU%20GPL%20v3.0-blue)](./LICENSE)
 <br>
 This is the frontend UI for Glimpse, the RPI TV website.


### PR DESCRIPTION
travis-ci.org is closing down.